### PR TITLE
Low: agents: pingd - Check pidfile on start

### DIFF
--- a/extra/resources/pingd
+++ b/extra/resources/pingd
@@ -200,6 +200,10 @@ pingd_start() {
 
     rc=$?
     if [ $rc = 0 ]; then
+        while ! pingd_monitor; do
+            ocf_log info "pingd still hasn't started yet. Waiting..."
+            sleep 1
+        done
 	exit $OCF_SUCCESS
     fi
     
@@ -233,10 +237,10 @@ pingd_monitor() {
     if [ ! -z $pid ]; then
 	kill -0 $pid
 	if [ $? = 0 ]; then
-	    exit $OCF_SUCCESS
+	    return $OCF_SUCCESS
 	fi
     fi
-    exit $OCF_NOT_RUNNING
+    return $OCF_NOT_RUNNING
 }
 
 pingd_validate() {


### PR DESCRIPTION
Occasionally, pingd's first monitor is failed after start.

```
test script
-------------------------------------
while true; do
    killall pingd; sleep 3
    rm -f /tmp/pingd.pid; sleep 1
    /usr/lib64/heartbeat/pingd -D -p /tmp/pingd.pid -a ping_status -d
0 -m 100 -h 192.168.0.1
   echo $?
   ls /tmp/pingd.pid; sleep .1
   ls /tmp/pingd.pid
done
-------------------------------------

result
-------------------------------------
0
/tmp/pingd.pid
/tmp/pingd.pid
0
ls: cannot access /tmp/pingd.pid:  No such file or directory   <- NG
/tmp/pingd.pid
0
/tmp/pingd.pid
/tmp/pingd.pid
0
/tmp/pingd.pid
/tmp/pingd.pid
0
/tmp/pingd.pid
/tmp/pingd.pid
0
ls: cannot access /tmp/pingd.pid: No such file or directory   <- NG
/tmp/pingd.pid
--------------------------------------
```
