### PR TITLE
Detect the lost of ICMP packet correctly

### DIFF
--- a/tools/pingd.c
+++ b/tools/pingd.c
@@ -862,7 +862,7 @@ ping_read(ping_node *node, int *lenp)
     
     if(bytes < 0) {
 	crm_perror(LOG_DEBUG, "Read failed");
-	if (saved_errno == EAGAIN || saved_errno == EINTR) {
+	if (saved_errno == EAGAIN && saved_errno == EINTR) {
 	    crm_debug("Retrying...");
 	    goto retry;
 	} else {


### PR DESCRIPTION
I requested the following change to deal with the unrelated ICMP packet handling.

"Ignore the unrelated ICMP packet and retrying next ping"
https://github.com/ClusterLabs/pacemaker-1.0/commit/c9e741582db558d653861f40e5e97bc4d9574deb

But it can not detect the following test case.
# iptables -A INPUT -p icmp -s 192.168.201.254 -j DROP

192.168.201.254 is the destination of the pinged, so it has to detect the lost of connectivity, but pinged is retrying hour and hour :'-(

This patch catch up this.
I am going to investigating the previous issue again, sorry for the trouble.
