### PR TITLE
Clean up for handling the unrelated ICMP packets

### DIFF
--- a/tools/pingd.c
+++ b/tools/pingd.c
@@ -862,10 +862,7 @@ ping_read(ping_node *node, int *lenp)
     
     if(bytes < 0) {
 	crm_perror(LOG_DEBUG, "Read failed");
-	if (saved_errno == EAGAIN && saved_errno == EINTR) {
-	    crm_debug("Retrying...");
-	    goto retry;
-	} else {
+	if (saved_errno != EAGAIN && saved_errno != EINTR) {
 	    int rc = 0;
 	    if(node->type == AF_INET6) {
 		rc = process_icmp6_error(node, (struct sockaddr_in6*)&(node->addr));
@@ -894,16 +891,12 @@ ping_read(ping_node *node, int *lenp)
 		return FALSE;
 	}
 
-	if(rc < 0) {
+	if(rc <= 0) {
 	    crm_debug("Retrying...");
 	    goto retry;
-	    
 	} else if(rc > 0) {
 	    crm_free(packet);
 	    return TRUE;
-	} else {
-	    crm_debug("Retrying...");
-	    goto retry;
 	}	
 	
     } else {


### PR DESCRIPTION
I recently complained about pingd, let me explain this again.
This is the long comment, but it's just for my memorandum and an excuse for our team :)

First of all, the original problem which was reported from our customer is here;
One day, pingd detected the network failure but there was no network trouble, it means that "manual ping command" returned the normal status.
They suspected pingd's improper behavior.
An important characteristic of their system was that they run Pacemaker and the other monitoring and control products, for example, Zabbix, Nagios, IBM Tivoli, and so on.
These products also call their own "ping" to monitor the target processes and Pacemaker's pingd had caught not only its ECHO REPLY but also the other services' packets.
Pingd handled the other's ECHO REPLY packet as the wrong one.
It's certainly wrong packet for pingd but it would be better to ignore these packets and retry to get the correct ECHO REPLY during its timeout period.

In the above case, 
- the received packet(ECHO REPLY) should be larger than zero byte.
- pingd says "unreachable" (detects network failure) in the original code.
