### PR TITLE
Fix build error; Builder quick Build 51 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1230,10 +1230,8 @@ if test -n "$LIBGNUTLS_CONFIG"; then
 	AC_MSG_CHECKING(for gnutls library flags)
 	GNUTLSLIBS="`$LIBGNUTLS_CONFIG --libs`";
 	AC_MSG_RESULT($GNUTLSLIBS)
-else
-	AC_CHECK_LIB(gnutls, gnutls_init)
 fi
-
+AC_CHECK_LIB(gnutls, gnutls_init)
 AC_CHECK_FUNCS(gnutls_priority_set_direct)
 
 AC_SUBST(GNUTLSHEAD)


### PR DESCRIPTION
This should fix the build error below.

---

Subject: buildbot failure in Pacemaker on quick
Date: Wed, 29 Aug 2012 12:24:08 +0200

The Buildbot has detected a new failure on builder quick while building Pacemaker.
Full details are available at:
 http://build.clusterlabs.org:8010/builders/quick/builds/51

Buildbot URL: http://build.clusterlabs.org:8010/

Buildslave for this Build: build

---

configure: ac_check_funcs requires ac_check_lib

see:
http://www.gnu.org/s/hello/manual/autoconf/Generic-Functions.html

Signed-off-by: Angus Salkeld asalkeld@redhat.com

Backported from: ClusterLabs/pacemaker@d4cbfea938e45b819a1263828c0e37f04d6b80d6
