### PR TITLE
"Low: agents: pingd: Make sure pingd process has terminated completely in stop"

### DIFF
--- a/extra/resources/pingd
+++ b/extra/resources/pingd
@@ -212,17 +212,30 @@ pingd_start() {
 }
 
 pingd_stop() {
+    local shutdown_timeout
+    local count
+
     if [ -f $OCF_RESKEY_pidfile ]; then
 	pid=`cat $OCF_RESKEY_pidfile`
     fi
     if [ ! -z $pid ]; then
 	kill -TERM $pid
-	rc=$?
 
-	if [ $rc = 0 -o $rc = 1 ]; then
-	    rm $OCF_RESKEY_pidfile
-	    exit $OCF_SUCCESS
-	fi
+	# stop waiting
+	shutdown_timeout=$((($OCF_RESKEY_CRM_meta_timeout/1000)-5))
+	count=0
+	while [ $count -lt $shutdown_timeout ]; do
+	    # check if process still exists
+	    kill -s 0 $pid > /dev/null 2>&1
+	    rc=$?
+	    if [ $rc -ne 0 ]; then
+		rm $OCF_RESKEY_pidfile
+		exit $OCF_SUCCESS
+	    fi
+	    count=$(expr $count + 1)
+	    sleep 1
+	    ocf_log info "pingd still hasn't stopped yet. Waiting..."
+	done
 
 	ocf_log err "Unexpected result from kill -TERM $pid: $rc"
 	exit $OCF_ERR_GENERIC


### PR DESCRIPTION
This is a correction to the problems that pingd-RA finishes before the stop of the pingd process.

The detailed phenomenon is written in the next link.

http://www.gossamer-threads.com/lists/linuxha/pacemaker/85212

Best Regards,
Hideo Yamauchi.
