### PR TITLE
Medium: shell: cibconf: Allow to use meta attributes ordered and collocated for group resource

### DIFF
--- a/shell/modules/cibconfig.py
+++ b/shell/modules/cibconfig.py
@@ -1152,6 +1152,8 @@ class CibContainer(CibObject):
             l += vars.clone_meta_attributes
         elif self.obj_type == "ms":
             l += vars.clone_meta_attributes + vars.ms_meta_attributes
+        elif self.obj_type == "group":
+            l += vars.group_meta_attributes
         rc = sanity_check_meta(self.obj_id,self.node,l)
         return rc
 

--- a/shell/modules/vars.py.in
+++ b/shell/modules/vars.py.in
@@ -121,6 +121,7 @@ class Vars(Singleton):
         "ordered", "notify", "interleave", "globally-unique",
         "clone-max", "clone-node-max", "clone-state", "description",
     )
+    group_meta_attributes = ("ordered", "collocated")
     ms_meta_attributes = (
         "master-max", "master-node-max", "description",
     )


### PR DESCRIPTION
These attributes are only available in Pacemaker-1.0.\* and they are deprecated in Pacemaker-1.1.\* and later.
Use resource_set instead.

---

I send the pull request of the patch which Mr. Dejan donated.
The next link has the details of the patch.

http://www.gossamer-threads.com/lists/linuxha/pacemaker/84578

Best Regards,
Hideo Yamauchi.
